### PR TITLE
Added endpoint : /command/removeAllFromCacheOrByVehicleId

### DIFF
--- a/transitclock/src/main/java/org/transitclock/core/dataCache/VehicleDataCache.java
+++ b/transitclock/src/main/java/org/transitclock/core/dataCache/VehicleDataCache.java
@@ -533,4 +533,13 @@ public class VehicleDataCache {
 		logger.debug("Removing from VehicleDataCache vehiclesMap vehicleId={}", vehicleId);
 		vehiclesMap.remove(vehicleId);
 	}
+
+	/**
+	 * Removes all vehicles from the vehiclesMap
+	 *
+	 */
+	public void removeVehicles() {
+		logger.debug("Removing all vehicles from VehicleDataCache vehiclesMap");
+		vehiclesMap.clear();
+	}
 }

--- a/transitclock/src/main/java/org/transitclock/ipc/interfaces/CacheQueryInterface.java
+++ b/transitclock/src/main/java/org/transitclock/ipc/interfaces/CacheQueryInterface.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * This file is part of Transitime.org
  * 
  * Transitime.org is free software: you can redistribute it and/or modify
@@ -32,7 +32,6 @@ import org.transitclock.ipc.data.IpcKalmanErrorCacheKey;
  * Defines the RMI interface used for obtaining cache runtime information. 
  * 
  * @author Sean Og Crudden
- *
  */
 public interface CacheQueryInterface extends Remote {
 		
@@ -119,4 +118,23 @@ public interface CacheQueryInterface extends Remote {
 	 */	
 	public  Double getKalmanErrorValue(String tripId, Integer stopPathIndex) throws RemoteException;
 
+    /**
+     * Return the removed id of vehicle if it does exist.
+     *
+     * @param vehicleId
+     * @return String with removed vehicle id
+     * @throws RemoteException
+     */
+    String removeVehicleFromCacheByVehicleId(String vehicleId)
+            throws RemoteException;
+
+    /**
+     * Return message of success clear cache of vehicles.
+     *
+     * @param vehicleId
+     * @return String with removed vehicle id
+     * @throws RemoteException
+     */
+    String removeAllVehiclesFromCache()
+            throws RemoteException;
 }

--- a/transitclock/src/main/java/org/transitclock/ipc/servers/CacheQueryServer.java
+++ b/transitclock/src/main/java/org/transitclock/ipc/servers/CacheQueryServer.java
@@ -14,24 +14,10 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.transitclock.core.dataCache.ErrorCacheFactory;
-import org.transitclock.core.dataCache.HistoricalAverage;
-import org.transitclock.core.dataCache.HoldingTimeCache;
-import org.transitclock.core.dataCache.HoldingTimeCacheKey;
-import org.transitclock.core.dataCache.IpcArrivalDepartureComparator;
-import org.transitclock.core.dataCache.KalmanErrorCacheKey;
-import org.transitclock.core.dataCache.StopArrivalDepartureCacheFactory;
-import org.transitclock.core.dataCache.StopArrivalDepartureCacheKey;
-import org.transitclock.core.dataCache.TripKey;
+import org.transitclock.core.dataCache.*;
 import org.transitclock.core.dataCache.frequency.FrequencyBasedHistoricalAverageCache;
 import org.transitclock.core.dataCache.scheduled.ScheduleBasedHistoricalAverageCache;
-import org.transitclock.core.dataCache.StopPathCacheKey;
-import org.transitclock.core.dataCache.TripDataHistoryCacheFactory;
-import org.transitclock.ipc.data.IpcArrivalDeparture;
-import org.transitclock.ipc.data.IpcHistoricalAverage;
-import org.transitclock.ipc.data.IpcHistoricalAverageCacheKey;
-import org.transitclock.ipc.data.IpcHoldingTimeCacheKey;
-import org.transitclock.ipc.data.IpcKalmanErrorCacheKey;
+import org.transitclock.ipc.data.*;
 import org.transitclock.ipc.interfaces.CacheQueryInterface;
 import org.transitclock.ipc.rmi.AbstractServer;
 
@@ -189,6 +175,7 @@ public class CacheQueryServer extends AbstractServer implements CacheQueryInterf
 		return result;
 	}
 
+
 	@Override
 	public List<IpcKalmanErrorCacheKey> getKalmanErrorCacheKeys() throws RemoteException {
 		List<KalmanErrorCacheKey> keys = ErrorCacheFactory.getInstance().getKeys();
@@ -218,5 +205,28 @@ public class CacheQueryServer extends AbstractServer implements CacheQueryInterf
 		// TODO Auto-generated method stub
 		FrequencyBasedHistoricalAverageCache.getInstance();
 		return null;
+	}
+
+	@Override
+	public String removeVehicleFromCacheByVehicleId(String vehicleId) throws RemoteException {
+
+		IpcVehicleComplete foundOrNull = VehicleDataCache.getInstance()
+				.getVehicle(vehicleId);
+		if (foundOrNull != null && foundOrNull.getAvl().getVehicleId().equals(vehicleId))
+		{
+			VehicleDataCache.getInstance().removeVehicle(vehicleId);
+			return vehicleId;
+		}
+		return "Unsuccess";
+	}
+
+	@Override
+	public String removeAllVehiclesFromCache() throws RemoteException {
+		VehicleDataCache.getInstance().removeVehicles();
+		boolean isVehicleCacheClear = VehicleDataCache
+				.getInstance()
+				.getVehicles()
+				.isEmpty();
+		return "Cache clear : " + isVehicleCacheClear;
 	}
 }

--- a/transitclockApi/src/main/java/org/transitclock/api/rootResources/CacheApi.java
+++ b/transitclockApi/src/main/java/org/transitclock/api/rootResources/CacheApi.java
@@ -381,7 +381,7 @@ public class CacheApi {
 		}
 	}
 
-	@Path("/command/removeAllFromCacheOrByVehicleId")
+	@Path("/command/clearAllCacheOrRemoveByVehicleId")
 	@POST
 	@Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 	@Operation(summary = "Remove a vehicle from cache by id if it does exist or clean all vehicles.",

--- a/transitclockApi/src/main/java/org/transitclock/api/rootResources/TransitimeApi.java
+++ b/transitclockApi/src/main/java/org/transitclock/api/rootResources/TransitimeApi.java
@@ -1428,16 +1428,13 @@ public class TransitimeApi {
           Collection<IpcActiveBlock> activeBlocks = vehiclesInterface
                   .getActiveBlocksAndVehiclesByRouteName(routeName,
                           allowableBeforeTimeSecs);
-          VehiclesInterface inter = stdParameters.getVehiclesInterface();
-			
-          
+
           for(IpcActiveBlock ipcActiveBlocks : activeBlocks) {
         	 for(IpcVehicle ipcVehicle : ipcActiveBlocks.getVehicles()) {
         		 for(IpcVehicleConfig iVC : vehiclesInterface.getVehicleConfigs()) {
         			 
         			 if(iVC.getId().equals(ipcVehicle.getId())) {
         				 ipcVehicle.setVehicleName(iVC.getName());
-        				 
         				 break;
         			 }
         		 }        		 


### PR DESCRIPTION
Dodałem kilka metod oraz endpoint "removeAllFromCacheOrByVehicleId" który usuwa nieaktualne pojazdy z cache a mianowicie z vehiclesMap za pomocą przekazania konkretnego vehicleId bądź argumentu "all" co skutkuje pojedyncze usunięcie albo wyczyszczenie całej tabeli vehiclesMap, dzięki czemu nie trzeba ururchamiać całego TC by się pozbyć nieaktualnych pojazdów z raportu "vehicleDetails"