### PR TITLE
Fix :  DateTimeParam to String in cancelTrip and reenableTrip endpoints

### DIFF
--- a/transitclockApi/src/main/java/org/transitclock/api/rootResources/CommandsApi.java
+++ b/transitclockApi/src/main/java/org/transitclock/api/rootResources/CommandsApi.java
@@ -349,76 +349,78 @@ public class CommandsApi {
 			throw WebUtils.badRequestException(e);
 		}
 	}
-// WORK IN PROGRESS	
+	// WORK IN PROGRESS
 	@Path("/command/cancelTrip/{tripId}")
-	@GET //SHOULD BE POST,IT IS AN UPDATE
+	@GET
 	@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
 	@Operation(summary="Cancel a trip in order to be shown in GTFS realtime.",
-	description="<font color=\"#FF0000\">Experimental. It will work olny with the correct version.</font> It cancel a trip that has no vechilce assigned."
-	,tags= {"command","trip"})
-	
+			description="<font color=\"#FF0000\">Experimental. It will work olny with the correct version.</font> It cancel a trip that has no vechilce assigned."
+			,tags= {"command","trip"})
+
 	public Response cancelTrip(@BeanParam StandardParameters stdParameters,
-			@Parameter(description="tripId to be marked as canceled.",required=true)@PathParam("tripId") String tripId,
-			@Parameter(description="start trip time",required=false) @QueryParam( value="at") DateTimeParam at
-			)
+							   @Parameter(description="tripId to be marked as canceled.",required=true)@PathParam("tripId") String tripId,
+							   @Parameter(description="start trip at time ex:(2024-02-02T20:20:00)",required=false) @QueryParam( value="at") String at
+	)
 	{
 		stdParameters.validate();
-		String result=null;
+		String result = null;
 		try
 		{
 			CommandsInterface inter = stdParameters.getCommandsInterface();
 			//We need to get the block id in order to get the vehicle
 			ConfigInterface cofingInterface = stdParameters.getConfigInterface();
 			IpcTrip ipcTrip = cofingInterface.getTrip(tripId);
-			if(ipcTrip==null)
+			if(ipcTrip == null)
 				throw WebUtils.badRequestException("TripId=" + tripId + " does not exist.");
-			result=inter.cancelTrip(tripId,at==null?null:at.getDate());
+			result = inter.cancelTrip(tripId, at == null ? null : new DateTimeParam(at).getDate());
+
 		}
 		catch (RemoteException e) {
 			e.printStackTrace();
-			throw WebUtils.badRequestException("Could not send request to Core server. "+e.getMessage());
+			throw WebUtils.badRequestException("Could not send request to Core server. "+ e.getMessage());
 		}
-		
-		if(result==null)
-			return stdParameters.createResponse(new ApiCommandAck(true,"Processed"));
+
+		if(result == null)
+			return stdParameters.createResponse(new ApiCommandAck(true,"Trip with tripId : "
+					+ tripId + " - is canceled"));
 		else
 			return stdParameters.createResponse(new ApiCommandAck(true,result));
 	}
-	
+
 	@Path("/command/reenableTrip/{tripId}")
 	@GET //SHOULD BE POST,IT IS AN UPDATE
 	@Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
 	@Operation(summary="Cancel a trip in order to be shown in GTFS realtime.",
-	description="<font color=\"#FF0000\">Experimental. It will work olny with the correct version.</font> It cancel a trip that has no vechilce assigned."
-	,tags= {"command","trip"})
-	 
+			description="<font color=\"#FF0000\">Experimental. It will work olny with the correct version.</font> It cancel a trip that has no vechilce assigned."
+			,tags= {"command","trip"})
+
 	public Response reenableTrip(@BeanParam StandardParameters stdParameters,
-			@Parameter(description="tripId to remove calceled satate.",required=true)@PathParam("tripId") String tripId,
-			@Parameter(description="start trip time",required=false) @QueryParam( value="at") DateTimeParam at)
+								 @Parameter(description="tripId to remove calceled satate.",required=true)@PathParam("tripId") String tripId,
+								 @Parameter(description="start trip at time ex:(2024-02-02T20:20:00)",required=false) @QueryParam( value="at") String at)
 	{
 		stdParameters.validate();
-		String result=null;
-		try
-		{
+		String result = null;
+
+		try {
 			CommandsInterface inter = stdParameters.getCommandsInterface();
 			//We need to get the block id in order to get the vehicle
 			ConfigInterface cofingInterface = stdParameters.getConfigInterface();
 			IpcTrip ipcTrip = cofingInterface.getTrip(tripId);
-			if(ipcTrip==null)
+			if(ipcTrip == null)
 				throw WebUtils.badRequestException("TripId=" + tripId + " does not exist.");
-			result=inter.reenableTrip(tripId,at==null?null:at.getDate());
+			result = inter.reenableTrip(tripId, at == null ? null : new DateTimeParam(at).getDate());
 		}
 		catch (RemoteException e) {
 			e.printStackTrace();
 			throw WebUtils.badRequestException("Could not send request to Core server. "+e.getMessage());
 		}
-		if(result==null)
-			return stdParameters.createResponse(new ApiCommandAck(true,"Processed"));
+		if(result == null)
+			return stdParameters.createResponse(new ApiCommandAck(true,"Trip with tripId : "
+					+ tripId + " - is reenabled"));
 		else
 			return stdParameters.createResponse(new ApiCommandAck(true,result));
 	}
-	
-	
+
 	@Operation(summary="Add vehicles to block",
 			description="Add vehicles to block",tags= {"vehicle","block"})
 	@Path("/command/vehicleToBlock")


### PR DESCRIPTION
Proszę sprawdzić zmiany. W poprzednim parametrze zawsze przekazywał się null 