### PR TITLE
Fix ndpoint vehiclesdetails + kilka drobnych updatów bibliotek 

### DIFF
--- a/transitclock/pom.xml
+++ b/transitclock/pom.xml
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>9.3-1103-jdbc41</version>
+			<version>42.6.0</version>
 		</dependency>
 
 		<dependency>

--- a/transitclock/pom.xml
+++ b/transitclock/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
-			<version>4.3.9.Final</version>
+			<version>4.3.11.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.common</groupId>
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-c3p0</artifactId>
-			<version>4.3.9.Final</version>
+			<version>4.3.11.Final</version>
 		</dependency>
 
 		<!-- hibernate-core loads in really old version of xml-apis so load in

--- a/transitclock/pom.xml
+++ b/transitclock/pom.xml
@@ -294,7 +294,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.5.1</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>

--- a/transitclock/src/main/java/org/transitclock/core/reports/Reports.java
+++ b/transitclock/src/main/java/org/transitclock/core/reports/Reports.java
@@ -627,7 +627,7 @@ private static final int MAX_NUM_DAYS = 7;
 			SQLQuery query = session.createSQLQuery(
 							"select vehicleId as \"vehicleId\"  from " +
 									"(SELECT DISTINCT vehicleId, max(time) AS maxTime " +
-					                "FROM avlreports WHERE time > now() + '-72 hours' " +
+					                "FROM avlreports WHERE time > now() + '-"+ hours +" hours' " +
 									"GROUP BY vehicleId) as vId");
 
 			vehicleIds = query.list();

--- a/transitclock/src/main/java/org/transitclock/core/reports/Reports.java
+++ b/transitclock/src/main/java/org/transitclock/core/reports/Reports.java
@@ -625,10 +625,10 @@ private static final int MAX_NUM_DAYS = 7;
 		if(agency.getDbType().equals("postgresql"))
 		{
 			SQLQuery query = session.createSQLQuery(
-							"select vehicleId as \"vehicleId\" from ("
-							+ "SELECT DISTINCT vehicleId, max(time) AS maxTime "
-							+ "FROM avlreports WHERE time > now() + '-" + hours + " hours' "
-							+ "GROUP BY vehicleId)");
+							"select vehicleId as \"vehicleId\"  from " +
+									"(SELECT DISTINCT vehicleId, max(time) AS maxTime " +
+					                "FROM avlreports WHERE time > now() + '-72 hours' " +
+									"GROUP BY vehicleId) as vId");
 
 			vehicleIds = query.list();
 		}

--- a/transitclockApi/pom.xml
+++ b/transitclockApi/pom.xml
@@ -111,7 +111,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.5.1</version>
+				<version>3.8.1</version>
 				<inherited>true</inherited>
 				<configuration>
 					<source>1.8</source>

--- a/transitclockApi/src/main/java/org/transitclock/api/rootResources/TransitimeApi.java
+++ b/transitclockApi/src/main/java/org/transitclock/api/rootResources/TransitimeApi.java
@@ -518,8 +518,6 @@ public class TransitimeApi {
         		 for(IpcVehicleConfig iVC : vehicleConfigs) {
         			 if(iVC.getId().equals(ipcVehicle.getId())) {
         				 ipcVehicle.setVehicleName(iVC.getName());
-         				 System.out.println(" Name:  " +  ipcVehicle.getVehicleName() + " - " + iVC.getName() + "   Id: " +
-								 ipcVehicle.getId()+ " - " + iVC.getId());
         				 break;
         			 }
         		 }        		 
@@ -535,8 +533,8 @@ public class TransitimeApi {
 			// Convert IpcVehiclesDetails to ApiVehiclesDetails
 			ApiVehiclesDetails apiVehiclesDetails = new ApiVehiclesDetails(vehicles, stdParameters.getAgencyId(),
 					uiTypesForVehicles,onlyAssigned);
-			
-			
+
+			System.out.println("VehicleDiteils dla " + vehicles.size() + " : pojazdów ");
 
 			// return ApiVehiclesDetails response
 			Response result = null;

--- a/transitclockApi/src/main/java/org/transitclock/api/rootResources/TransitimeApi.java
+++ b/transitclockApi/src/main/java/org/transitclock/api/rootResources/TransitimeApi.java
@@ -534,7 +534,7 @@ public class TransitimeApi {
 			ApiVehiclesDetails apiVehiclesDetails = new ApiVehiclesDetails(vehicles, stdParameters.getAgencyId(),
 					uiTypesForVehicles,onlyAssigned);
 
-			System.out.println("VehicleDiteils dla " + vehicles.size() + " : pojazdów ");
+			System.out.println("VehicleDiteils for " + vehicles.size() + " : vehicles ");
 
 			// return ApiVehiclesDetails response
 			Response result = null;

--- a/transitclockTraccarClient/pom.xml
+++ b/transitclockTraccarClient/pom.xml
@@ -46,10 +46,10 @@
 			<plugins>
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.5.1</version>
+					<version>3.8.1</version>
 					<configuration>
-						<source>1.7</source>
-						<target>1.7</target>
+						<source>1.8</source>
+						<target>1.8</target>
 					</configuration>
 				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/transitclockWebapp/pom.xml
+++ b/transitclockWebapp/pom.xml
@@ -55,7 +55,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.5.1</version>
+				<version>3.8.1</version>
 				<inherited>true</inherited>
 				<configuration>
 					<source>1.8</source>


### PR DESCRIPTION
Fix do Reports.hasLastAvlJsonInHours(); działa z nowszymi wersjami postgres: jeśli nie chcemy tego to można dopasować te zmiany do postgres 9.6 i pozostać przy starej wersji.